### PR TITLE
Correct path names for chrony sources

### DIFF
--- a/section_2/cis_2.3/cis_2.3.3.1.yml
+++ b/section_2/cis_2.3/cis_2.3.3.1.yml
@@ -6,7 +6,7 @@
 file:
   chrony_pool:
     title: 2.3.3.1 | Ensure chrony is configured with authorized timeserver | timeserver pool
-    path: /etc/chrony/sources.d/pool.source
+    path: /etc/chrony/sources.d/pool.sources
     exists: true
     contents:
     {{- range .Vars.ubtu24cis_time_pool }}
@@ -26,7 +26,7 @@ file:
       - AU-12
   chrony_timeservers:
     title: 2.3.3.1 | Ensure chrony is configured with authorized timeserver | timeserver servers
-    path: /etc/chrony/sources.d/server.source
+    path: /etc/chrony/sources.d/server.sources
     exists: true
     contents:
     {{- range .Vars.ubtu24cis_time_servers }}


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Minor typo in 2.3.3.1 audit rules was causing skips/failures. Proposed fix to address this.

**Issue Fixes:**
#13 

**Enhancements:**

**How has this been tested?:**
Tested locally as pre/post remediation with lockdown playbook. Made changes directly to audit content and set `audit_content: other`
