### PR TITLE
Align 1.1.2.X.1 to CIS & fix 6.1.1.4

### DIFF
--- a/section_1/cis_1.1/cis_1.1.2.3.1.yml
+++ b/section_1/cis_1.1/cis_1.1.2.3.1.yml
@@ -1,6 +1,6 @@
 ---
 
-{{ if .Vars.ubtu24cis_level_1 }}
+{{ if .Vars.ubtu24cis_level_2 }}
   {{ if .Vars.ubtu24cis_rule_1_1_2_3_1 }}
 mount:
   home_mount:
@@ -8,8 +8,8 @@ mount:
     mountpoint: /home
     exists: true
     meta:
-      server: 1
-      workstation: 1
+      server: 2
+      workstation: 2
       CIS_ID:
       - 1.1.2.3.1
       CISv8: 4.8

--- a/section_1/cis_1.1/cis_1.1.2.4.1.yml
+++ b/section_1/cis_1.1/cis_1.1.2.4.1.yml
@@ -1,6 +1,6 @@
 ---
 
-{{ if .Vars.ubtu24cis_level_1 }}
+{{ if .Vars.ubtu24cis_level_2 }}
   {{ if .Vars.ubtu24cis_rule_1_1_2_4_1 }}
 mount:
   var_mount:
@@ -8,8 +8,8 @@ mount:
     mountpoint: /var
     exists: true
     meta:
-      server: 1
-      workstation: 1
+      server: 2
+      workstation: 2
       CIS_ID:
       - 1.1.2.4.1
       CISv8: 3.3

--- a/section_1/cis_1.1/cis_1.1.2.5.1.yml
+++ b/section_1/cis_1.1/cis_1.1.2.5.1.yml
@@ -1,6 +1,6 @@
 ---
 
-{{ if .Vars.ubtu24cis_level_1 }}
+{{ if .Vars.ubtu24cis_level_2 }}
   {{ if .Vars.ubtu24cis_rule_1_1_2_5_1 }}
 mount:
   var_tmp_mount:
@@ -8,8 +8,8 @@ mount:
     mountpoint: /var/tmp
     exists: true
     meta:
-      server: 1
-      workstation: 1
+      server: 2
+      workstation: 2
       CIS_ID:
       - 1.1.2.5.1
       CISv8: 3.3

--- a/section_1/cis_1.1/cis_1.1.2.6.1.yml
+++ b/section_1/cis_1.1/cis_1.1.2.6.1.yml
@@ -1,6 +1,6 @@
 ---
 
-{{ if .Vars.ubtu24cis_level_1 }}
+{{ if .Vars.ubtu24cis_level_2 }}
   {{ if .Vars.ubtu24cis_rule_1_1_2_6_1 }}
 mount:
   var_log_mount:

--- a/section_1/cis_1.1/cis_1.1.2.7.1.yml
+++ b/section_1/cis_1.1/cis_1.1.2.7.1.yml
@@ -1,6 +1,6 @@
 ---
 
-{{ if .Vars.ubtu24cis_level_1 }}
+{{ if .Vars.ubtu24cis_level_2 }}
   {{ if .Vars.ubtu24cis_rule_1_1_2_7_1 }}
 mount:
   var_log_audit_mount:

--- a/section_6/cis_6.1.1.x/cis_6.1.1.4.yml
+++ b/section_6/cis_6.1.1.x/cis_6.1.1.4.yml
@@ -6,7 +6,7 @@ service:
   {{ if eq .Vars.ubtu24cis_syslog_service "journald" }}
   single_syslog_journald_running:
     title: 6.1.1.4 | Ensure only one logging system is in use | journald running
-    name: systemd-jounald.service
+    name: systemd-journald.service
     running: true
     enabled: true
     meta:
@@ -38,7 +38,7 @@ service:
       - 6.1.1.4
   single_syslog_journald_stopped:
     title: 6.1.1.4 | Ensure only one logging system is in use | journald stopped
-    name: systemd-jounald.service
+    name: systemd-journald.service
     running: false
     enabled: false
     meta:


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
- Correctly aligns 1.1.2.3.1, 1.1.2.4.1, 1.1.2.5.1, 1.1.2.6.1, 1.1.2.7.1 to CIS Level 2
- Fixes a typo in 6.1.1.4 that resulted in an erroneous failure 
